### PR TITLE
feat(population): use Census intercensal estimates for 2000-2020

### DIFF
--- a/population/usa/20y_10y_5y_bins.r
+++ b/population/usa/20y_10y_5y_bins.r
@@ -155,7 +155,7 @@ get_latest_vintage <- function() {
     result <- tryCatch(read.csv(url), error = function(e) NULL)
     if (!is.null(result)) {
       if (yr < current_year) {
-        warning("Vintage ", current_year, " not available, using Vintage ", yr)
+        message("Vintage ", current_year, " not available, using Vintage ", yr)
       } else {
         message("Using Vintage ", yr)
       }


### PR DESCRIPTION
- Switch from static vintage files to official intercensal estimates
  - 2000-2010: st-est00int-agesex.csv (adjusted for 2010 Census)
  - 2010-2020: sc-est2020int-alldata6.csv (adjusted for 2020 Census)
- Add auto-detection for latest vintage (2024, 2025, etc.)
- Remove manual ratio-based scaling (no longer needed with intercensal)
- Dynamic column selection for future vintage compatibility

Intercensal estimates are Census Bureau's official retrospective population figures, recommended as denominators for mortality rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)