### PR TITLE
feat(le): extend nax coefficients for broader age groups

### DIFF
--- a/lib/life_expectancy.r
+++ b/lib/life_expectancy.r
@@ -84,18 +84,22 @@ estimate_nax <- function(nMx, ages, AgeInt, sex = "t") {
 
       } else if (n == 10) {
         # 0-9: Approximate using weighted infant concentration
-        # ~70% of deaths in 0-9 occur in age 0, ~20% in 1-4, ~10% in 5-9
-        a0 <- if (m0 * n >= 0.107) 0.34 else 0.049 + 2.742 * m0 * n
+        # Weights are empirical approximations based on typical mortality patterns
+        # in populations where ~70% of 0-9 deaths occur in age 0
+        # Note: m0 here is group mortality rate, used as proxy for infant mortality
+        a0 <- if (m0 >= 0.107) 0.34 else 0.049 + 2.742 * m0
         nax[i] <- 0.70 * a0 + 0.20 * (1 + 1.5) + 0.10 * (5 + 2.5)
 
       } else if (n <= 15) {
         # 0-14: Similar approach, deaths concentrated in infancy
-        # ~65% in age 0, ~20% in 1-4, ~15% in 5-14
-        a0 <- if (m0 * n >= 0.107) 0.34 else 0.049 + 2.742 * m0 * n
+        # Weights are empirical approximations (~65% in age 0, ~20% in 1-4)
+        a0 <- if (m0 >= 0.107) 0.34 else 0.049 + 2.742 * m0
         nax[i] <- 0.65 * a0 + 0.20 * (1 + 1.5) + 0.15 * (5 + 5)
 
       } else {
-        # Broader than 0-14: less reliable, weight toward younger ages
+        # Broader than 0-14: fallback for direct calls to estimate_nax()
+        # Note: calculate_le_all_ages() and calculate_e0() return NA for these
+        # cases before reaching here, so this only applies to direct usage
         nax[i] <- n / 3
       }
 


### PR DESCRIPTION
## Summary

Extends the life expectancy calculation to handle broader first age groups commonly found in mortality data sources:

- **0-4**: Standard Coale-Demeny coefficients (Preston et al. 2001)
- **0-9**: Weighted approximation (~70% infant mortality concentration)
- **0-14**: Weighted approximation (~65% infant mortality concentration)
- **0-24+**: Skipped (unreliable)

Also adds proper Coale-Demeny coefficients for ages 1-4 (which depend on infant mortality level).

## Data Sources Affected

| First Age Group | Sources | Records | Status |
|-----------------|---------|---------|--------|
| 0-9 | eurostat, destatis, CDC | 103 | ✓ Now supported |
| 0-14 | mortality_org | 38 | ✓ Now supported |
| 0-24+ | statcan, some CDC | 49 | ✗ Skipped (too broad) |

## Changes

1. **Extended `estimate_nax()`** with coefficients for 0-4, 0-9, 0-14
2. **Added validation** to skip unreliable age groups (width > 15 years)
3. **Added documentation** with methodology, references, and data quality requirements

## References

- Preston, S.H., Heuveline, P., & Guillot, M. (2001). *Demography: Measuring and Modeling Population Processes*
- Coale, A.J. & Demeny, P. (1966). *Regional Model Life Tables and Stable Populations*
- Chiang, C.L. (1984). *The Life Table and Its Applications*

## Test plan

- [ ] Verify LE calculation works for eurostat data (0-9 first group)
- [ ] Verify LE calculation works for mortality_org data (0-14 first group)
- [ ] Verify LE returns NA for statcan data (0-44 first group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)