### PR TITLE
fix: use best available LE source regardless of deaths source

### DIFF
--- a/mortality/world_dataset.r
+++ b/mortality/world_dataset.r
@@ -121,11 +121,21 @@ process_country <- function(df) {
       group_by(iso3c, date, type, source) |>
       slice(1) |>
       ungroup() |>
-      select(iso3c, date, type, source, le)
+      select(iso3c, date, type, source, n_age_groups, le)
 
-    # Merge e0 into ASMR data (for "all" age group output)
+    # Pick best LE per date (prefer non-NA with highest n_age_groups)
+    # This allows using eurostat LE even when destatis is preferred for deaths
+    dd_le_best <- dd_le_e0 |>
+      filter(!is.na(le)) |>
+      group_by(iso3c, date) |>
+      arrange(desc(n_age_groups)) |>
+      slice(1) |>
+      ungroup() |>
+      select(iso3c, date, le, source_le = source)
+
+    # Merge best LE into ASMR data (not requiring source match)
     dd_asmr <- dd_asmr |>
-      left_join(dd_le_e0, by = c("iso3c", "date", "type", "source"))
+      left_join(dd_le_best, by = c("iso3c", "date"))
 
     # Merge LE into age-specific data (for individual age group outputs)
     dd_age <- dd_age |>

--- a/mortality/world_dataset_functions.r
+++ b/mortality/world_dataset_functions.r
@@ -60,6 +60,7 @@ aggregate_data <- function(data, type) {
   }
 
   if ("asmr_who" %in% names(data)) {
+    has_source_le <- "source_le" %in% names(data)
     if (has_le) {
       result <- result |>
         summarise(
@@ -69,10 +70,11 @@ aggregate_data <- function(data, type) {
           asmr_country = round(sum_if_not_empty(.data$asmr_country), digits = 1),
           le = round(mean(.data$le, na.rm = TRUE), 2),
           source_asmr = toString(unique(.data$source)),
+          source_le = if (has_source_le) toString(unique(.data$source_le)) else NA_character_,
           .groups = "drop"
         )
       if (all(is.na(result$le) | is.nan(result$le))) {
-        result <- result |> select(-le)
+        result <- result |> select(-le, -source_le)
       }
     } else {
       result <- result |>


### PR DESCRIPTION
## Summary
- Picks the best LE per date by preferring sources with higher n_age_groups
- Allows eurostat LE (0-9 first age group) to be used even when destatis provides deaths/ASMR
- Adds `source_le` column to track which source provided the LE

## Problem
Germany weekly LE was missing because:
1. destatis is prioritized over eurostat for deaths (more timely)
2. destatis weekly data has "0-29" as first age group (width=30)
3. LE calculation requires first age group width ≤ 15
4. eurostat has "0-9" (width=10) which works, but wasn't being used

## Solution
Decouple LE source selection from deaths source - pick the best available LE regardless of which source provides deaths/ASMR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)