### PR TITLE
Apply LE bin-correction to adjusted sub-yearly LE

### DIFF
--- a/mortality/world_dataset.r
+++ b/mortality/world_dataset.r
@@ -149,7 +149,7 @@ process_country <- function(df) {
       ungroup() |>
       select(
         iso3c, date, le, le_unavailable_reason,
-        source_le = source, le_source_type = type
+        source_le = source, le_source_type = type, n_age_groups_le = n_age_groups
       )
 
     dd_le_best_unavailable <- dd_le_e0 |>
@@ -161,12 +161,13 @@ process_country <- function(df) {
       ungroup() |>
       select(
         iso3c, date, le, le_unavailable_reason,
-        source_le = source, le_source_type = type
+        source_le = source, le_source_type = type, n_age_groups_le = n_age_groups
       )
 
     dd_le_best <- bind_rows(dd_le_best_computed, dd_le_best_unavailable) |>
       select(
-        iso3c, date, le, le_unavailable_reason, source_le, le_source_type
+        iso3c, date, le, le_unavailable_reason,
+        source_le, le_source_type, n_age_groups_le
       )
 
     # Merge best LE into ASMR data (not requiring source match)

--- a/mortality/world_dataset_functions.r
+++ b/mortality/world_dataset_functions.r
@@ -305,6 +305,7 @@ aggregate_data <- function(data, type) {
           } else {
             NA_character_
           },
+          n_age_groups_le = if ("n_age_groups_le" %in% names(data)) round(mean(.data$n_age_groups_le, na.rm = TRUE)) else if ("n_age_groups" %in% names(data)) round(mean(.data$n_age_groups, na.rm = TRUE)) else NA_real_,
           type = toString(unique(.data$type)),
           source = toString(unique(.data$source)),
           .groups = "drop"
@@ -355,6 +356,7 @@ aggregate_data <- function(data, type) {
           } else {
             NA_character_
           },
+          n_age_groups_le = if ("n_age_groups_le" %in% names(data)) round(mean(.data$n_age_groups_le, na.rm = TRUE)) else if ("n_age_groups" %in% names(data)) round(mean(.data$n_age_groups, na.rm = TRUE)) else NA_real_,
           source_asmr = toString(unique(.data$source)),
           source_le = if (has_source_le) toString(unique(.data$source_le)) else NA_character_,
           .groups = "drop"
@@ -465,6 +467,15 @@ round_x <- function(data, col_name, digits = 0) {
     )
 }
 
+# LE bin-bias correction (years) based on validation against single-age reference.
+# Applied only to le_adj (sub-yearly adjusted LE), keeping raw le unchanged.
+get_le_bin_bias <- function(n_age_groups_le) {
+  ifelse(
+    is.na(n_age_groups_le), 0,
+    ifelse(n_age_groups_le == 19, 0.0551, ifelse(n_age_groups_le == 11, 0.0101, 0))
+  )
+}
+
 summarize_data_all <- function(dd_all, dd_asmr, type) {
   a <- summarize_data_by_time(dd_all, type)
   if (nrow(dd_asmr) == 0) {
@@ -545,7 +556,12 @@ smooth_le_stl <- function(df, type) {
   # Seasonally adjusted = trend + residual (removes seasonal artifact only)
   trend <- as.numeric(stl_result$time.series[, "trend"])
   residual <- as.numeric(stl_result$time.series[, "remainder"])
-  df$le_adj <- round(trend + residual, 2)
+  df$le_adj <- trend + residual
+
+  # Blend bin-structure correction into adjusted LE (default display path).
+  # If n_age_groups_le is unavailable, no correction is applied.
+  n_le <- if ("n_age_groups_le" %in% names(df)) df$n_age_groups_le else NA_real_
+  df$le_adj <- round(df$le_adj - get_le_bin_bias(n_le), 2)
 
   df
 }

--- a/mortality/world_dataset_functions.r
+++ b/mortality/world_dataset_functions.r
@@ -578,6 +578,49 @@ fill_gaps_na <- function(df) {
 }
 
 save_info <- function(df, upload) {
+  parse_age_group_start <- function(age_group) {
+    ag <- trimws(age_group)
+    m <- regmatches(ag, regexpr("^[0-9]+", ag))
+    if (length(m) == 0 || m == "") {
+      return(Inf)
+    }
+    as.numeric(m)
+  }
+
+  canonicalize_age_groups <- function(age_groups) {
+    ag <- unique(trimws(age_groups))
+    ag <- ag[!is.na(ag) & ag != ""]
+    has_all <- any(tolower(ag) == "all")
+    bins <- ag[tolower(ag) != "all"]
+
+    if (length(bins) > 0) {
+      bins <- bins[order(vapply(bins, parse_age_group_start, numeric(1)), bins)]
+    }
+
+    age_groups_bins <- paste(bins, collapse = ", ")
+    age_groups_canonical <- if (has_all) {
+      if (nzchar(age_groups_bins)) {
+        paste0("all, ", age_groups_bins)
+      } else {
+        "all"
+      }
+    } else {
+      age_groups_bins
+    }
+    bin_schema_id <- if (length(bins) == 0) {
+      "all"
+    } else {
+      gsub("[^0-9a-z]+", "_", tolower(age_groups_bins))
+    }
+
+    list(
+      age_groups_bins = age_groups_bins,
+      age_groups_canonical = age_groups_canonical,
+      n_age_groups_meta = length(bins),
+      bin_schema_id = bin_schema_id
+    )
+  }
+
   result <- tibble()
   for (code in unique(df$iso3c)) {
     df_country <- df |> filter(.data$iso3c == code)
@@ -585,6 +628,7 @@ save_info <- function(df, upload) {
       df_country_type <- df_country |> filter(.data$type == t)
       for (s in unique(df_country_type$source)) {
         df_country_type_source <- df_country_type |> filter(.data$source == s)
+        age_meta <- canonicalize_age_groups(unique(df_country_type_source$age_group))
         result <- rbind(
           result,
           tibble(
@@ -597,7 +641,12 @@ save_info <- function(df, upload) {
             age_groups = paste(
               unique(df_country_type_source$age_group),
               collapse = ", "
-            )
+            ),
+            age_groups_bins = age_meta$age_groups_bins,
+            age_groups_canonical = age_meta$age_groups_canonical,
+            n_age_groups_meta = age_meta$n_age_groups_meta,
+            bin_schema_id = age_meta$bin_schema_id,
+            le_bin_bias_adj_years = get_le_bin_bias(age_meta$n_age_groups_meta)
           )
         )
       }


### PR DESCRIPTION
## Summary
- carry n_age_groups from LE source rows into merged all-ages output as n_age_groups_le
- apply calibrated age-bin bias correction inside le_adj after STL decomposition for sub-yearly LE
- keep raw le unchanged; correction is only on adjusted values

## Notes
- unrelated local edits were discarded before creating this branch