### PR TITLE
Add US dataset runner and suppress weekly parse warnings

### DIFF
--- a/mortality/usa/deaths_weekly.r
+++ b/mortality/usa/deaths_weekly.r
@@ -33,7 +33,9 @@ parse_data <- function(df, jurisdiction_column, age_group) {
 get_csv <- function(j, a) {
   files <- Sys.glob(paste0("../wonder_dl/data_wonder/weekly/", j, "_", a, "_*.txt"))
   df <- bind_rows(lapply(files, function(f) {
-    read_delim(f, delim = "\t", col_types = cols(.default = "c"))
+    suppressWarnings(
+      read_delim(f, delim = "\t", col_types = cols(.default = "c"))
+    )
   }))
   parse_data(df, ifelse(j == "usa", "", "Residence State"), a)
 }

--- a/run_us_dataset.sh
+++ b/run_us_dataset.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+Rscript mortality/usa/deaths_weekly.r
+Rscript mortality/usa/deaths_weekly_25y_20y_10y.r
+Rscript mortality/usa/deaths_monthly.r
+Rscript mortality/usa/deaths_yearly.r


### PR DESCRIPTION
## Summary
- add  to run the US processing scripts in order
- suppress expected weekly CDC WONDER footer parsing warnings in 

## Why
- makes manual and cron execution simpler and less error-prone
- removes noisy non-actionable parse warnings from weekly files