### PR TITLE
Fix read_remote for readr literal CSV input

### DIFF
--- a/lib/common.r
+++ b/lib/common.r
@@ -224,7 +224,7 @@ read_remote <- function(path) {
       response <- GET(url)
       stop_for_status(response)
       content <- content(response, "text")
-      read_csv(content, show_col_types = FALSE)
+      read_csv(I(content), show_col_types = FALSE)
     },
     error = function(e) {
       message("Error reading: ", url)


### PR DESCRIPTION
## Summary
- wrap literal CSV text in `I()` inside `read_remote()`
- prevent readr warning from becoming fatal under `options(warn = 2)`

## Why
`read_csv(content)` now warns for literal strings in newer readr versions. This project treats warnings as errors, causing world dataset jobs to fail.

## Change
- `read_csv(content, show_col_types = FALSE)` -> `read_csv(I(content), show_col_types = FALSE)`
