### PR TITLE
Accept ISO-week-sourced years at >= 51 weeks of data

### DIFF
--- a/mortality/world_dataset_functions.r
+++ b/mortality/world_dataset_functions.r
@@ -1,9 +1,34 @@
-filter_by_complete_temp_values <- function(data, fun_name, n) {
+# Keep head/tail periods only when they have enough daily rows to be considered
+# complete. `n` is the standard threshold; `n_iso_week` (optional) is a relaxed
+# threshold that applies when every row of the head/tail period was sourced
+# from ISO weekly data (type == 3). ISO weeks straddle calendar-year
+# boundaries, so a fully-published ISO year (W01..W52/W53) covers ~362
+# calendar days of the nominal year — it never reaches the 365-day threshold
+# even when the source is complete (see issue #18).
+filter_by_complete_temp_values <- function(data, fun_name, n, n_iso_week = n) {
+  keep_period <- function(df) {
+    if (nrow(df) >= n) {
+      return(TRUE)
+    }
+    if ("type" %in% names(df) && all(df$type == 3) && nrow(df) >= n_iso_week) {
+      return(TRUE)
+    }
+    FALSE
+  }
+
+  filter_edge <- function(df) {
+    if (nrow(df) == 0) {
+      return(df)
+    }
+    df |>
+      group_by(across(all_of(fun_name))) |>
+      group_modify(~ if (keep_period(.x)) .x else .x[0, ]) |>
+      ungroup()
+  }
+
   start <- data |>
     filter(.data[[fun_name]] == head(data[[fun_name]], n = 1)) |>
-    group_by(across(all_of(fun_name))) |>
-    filter(n() >= n) |>
-    ungroup()
+    filter_edge()
   mid <- data |>
     filter(!.data[[fun_name]] %in% c(
       head(data, n = 1)[[fun_name]],
@@ -11,21 +36,23 @@ filter_by_complete_temp_values <- function(data, fun_name, n) {
     ))
   end <- data |>
     filter(.data[[fun_name]] == tail(data, n = 1)[[fun_name]]) |>
-    group_by(across(all_of(fun_name))) |>
-    filter(n() >= n) |>
-    ungroup()
+    filter_edge()
 
   rbind(start, mid, end) |>
     group_by(across(all_of(c("iso3c", fun_name))))
 }
 
 aggregate_data <- function(data, type) {
-  # Filter ends
+  # Filter ends. For "year", allow ISO-weekly-sourced years (type == 3) to
+  # pass at >= 51 weeks (357 days) since ISO weeks cannot cover all 365
+  # calendar days of a year (issue #18). fluseason / midyear keep the strict
+  # 365-day threshold for now — their boundaries don't line up with ISO
+  # week 1, so the same relaxation isn't obviously safe there.
   result <- switch(type,
     "yearweek" = filter_by_complete_temp_values(data, type, 7),
     "yearmonth" = filter_by_complete_temp_values(data, type, 28),
     "yearquarter" = filter_by_complete_temp_values(data, type, 90),
-    "year" = filter_by_complete_temp_values(data, type, 365),
+    "year" = filter_by_complete_temp_values(data, type, 365, n_iso_week = 357),
     "fluseason" = filter_by_complete_temp_values(data, type, 365),
     "midyear" = filter_by_complete_temp_values(data, type, 365)
   )


### PR DESCRIPTION
## Summary
Fixes #18. SWE 2025 was missing from `yearly.csv` even though every ISO week of 2025 had data in `weekly.csv`. The yearly aggregator required >= 365 expanded daily rows per head/tail year, but ISO weekly sources can never reach 365 calendar days of a nominal year — W01 straddles the prior year and Dec 29-31 fall into W01 of the following year (which Eurostat hasn't published yet).

## Change
In `mortality/world_dataset_functions.r`:

- `filter_by_complete_temp_values()` gains an optional `n_iso_week` argument. A head/tail period is kept if it has `>= n` rows, **or** every row in that period has `type == 3` (ISO weekly source) and it has `>= n_iso_week` rows.
- `aggregate_data()` calls the yearly path with `n = 365, n_iso_week = 357` (51 weeks * 7). Other periods are unchanged.
- The `type` column is preserved by `expand_daily()` (each daily row inherits `type` from its source via `uncount()`), so the check fires correctly downstream.

Trade-off: a year backed entirely by ISO weekly data now passes with as few as 357 days. Years with mixed source types still require the full 365.

## Verification
- `Rscript -e 'parse(file = "mortality/world_dataset_functions.r")'` parses cleanly.
- Synthetic input mimicking SWE 2025 (362 rows, all `type == 3`) is now retained; a mixed-source 362-row year is still dropped; the function with default `n_iso_week = n` reproduces the previous behavior exactly.

## Not changed (worth a follow-up?)
- `fluseason` and `midyear` still use the strict 365-day threshold. Their period boundaries (July 1 / July 1 for midyear, ~week 27 for fluseason) don't line up with ISO week 1, so the 357-day relaxation isn't obviously safe there. If those outputs are also missing for ISO-weekly-sourced jurisdictions, we should treat that as a separate ticket with its own boundary analysis rather than silently relaxing them here.
- `MAX_FIRST_AGE_GROUP_WIDTH` and the `aggregate_data` LE summarise path are out of scope (other tickets).