### PR TITLE
Compute LE for broad-first-bucket sources, flag with le_warning

### DIFF
--- a/lib/life_expectancy.r
+++ b/lib/life_expectancy.r
@@ -24,6 +24,9 @@
 # - First age group width <= 15 years (0-4, 0-9, or 0-14)
 # - Open-ended terminal age group (80+, 85+, 90+)
 # - Complete age coverage (no gaps)
+# Sources with a broader first age group still produce an estimate via the
+# n / 3 nax fallback, but the row carries `le_warning = TRUE` so the frontend
+# can mark it as reduced accuracy.
 #
 # References:
 # - Chiang, C.L. (1984). The Life Table and Its Applications
@@ -32,8 +35,11 @@
 # - Coale, A.J. & Demeny, P. (1966). Regional Model Life Tables and Stable
 #   Populations
 
-# Maximum width of first age group for reliable LE calculation
-# Groups broader than this (e.g., 0-24, 0-44) are too heterogeneous
+# Maximum width of first age group for reliable LE calculation.
+# Groups broader than this (e.g., 0-24, 0-44, 0-64) are too heterogeneous to
+# produce a fully accurate first-bucket nax estimate. We still compute LE for
+# such inputs (estimate_nax() falls back to n / 3), but the row is flagged via
+# `le_warning = TRUE` so the frontend can surface a "reduced accuracy" note.
 MAX_FIRST_AGE_GROUP_WIDTH <- 15
 
 #' Estimate nax (average years lived in interval by those who die)
@@ -97,9 +103,9 @@ estimate_nax <- function(nMx, ages, AgeInt, sex = "t") {
         nax[i] <- 0.65 * a0 + 0.20 * (1 + 1.5) + 0.15 * (5 + 5)
 
       } else {
-        # Broader than 0-14: fallback for direct calls to estimate_nax()
-        # Note: calculate_le_all_ages() and calculate_e0() return NA for these
-        # cases before reaching here, so this only applies to direct usage
+        # Broader than 0-14 (e.g. Brandenburg's 0-64): coarse fallback. Result
+        # is approximate, so calculate_le_all_ages() flags the output row with
+        # `le_warning = TRUE` and the frontend renders a reduced-accuracy note.
         nax[i] <- n / 3
       }
 
@@ -250,12 +256,10 @@ calculate_e0 <- function(df, sex = "t", annualize = TRUE) {
   AgeInt <- age_info$intervals[ord]
   nMx <- nMx[ord]
 
-  # Skip if first age group is too broad for reliable LE calculation
-  if (ages[1] == 0 && !is.na(AgeInt[1]) && AgeInt[1] > MAX_FIRST_AGE_GROUP_WIDTH) {
-    return(NA_real_)
-  }
-
-  # Build life table
+  # Sources whose first age group is broader than MAX_FIRST_AGE_GROUP_WIDTH
+  # (e.g. Brandenburg's 0-64) still get an estimate via the n / 3 fallback in
+  # estimate_nax(); calculate_le_all_ages() flags the row separately so the
+  # frontend can show a reduced-accuracy note.
   lt <- tryCatch(
     chiang_life_table(nMx, ages, AgeInt, sex),
     error = function(e) NULL
@@ -332,18 +336,27 @@ parse_age_groups_for_le <- function(age_groups) {
 #'   Deaths should be daily counts (annual deaths / 365) when annualize=TRUE.
 #' @param annualize Logical: if TRUE (default), multiply mortality rates by 365
 #'   to convert daily rates to annual rates. Set to FALSE for annual data.
-#' @return Data frame with age_group and le columns
+#' @return Data frame with age_group, le, and le_warning columns. `le_warning`
+#'   is TRUE when the source's first age group is broader than
+#'   MAX_FIRST_AGE_GROUP_WIDTH (e.g. Brandenburg's 0-64) and the first-bucket
+#'   nax therefore relies on a coarse n / 3 fallback.
 calculate_le_all_ages <- function(df, annualize = TRUE) {
+  empty_result <- tibble(
+    age_group = character(),
+    le = numeric(),
+    le_warning = logical()
+  )
+
   # Need at least some data
   if (nrow(df) == 0) {
-    return(tibble(age_group = character(), le = numeric()))
+    return(empty_result)
   }
 
   # Parse age groups to get numeric starts
   age_info <- parse_age_groups_for_le(df$age_group)
 
   if (is.null(age_info) || length(age_info$ages) < 2) {
-    return(tibble(age_group = character(), le = numeric()))
+    return(empty_result)
   }
 
   # Calculate mortality rates (deaths per person, NOT per 100k)
@@ -354,7 +367,7 @@ calculate_le_all_ages <- function(df, annualize = TRUE) {
 
   # Check if all mortality rates are zero (no deaths)
   if (all(nMx == 0)) {
-    return(tibble(age_group = character(), le = numeric()))
+    return(empty_result)
   }
 
   # Annualize daily mortality rates to get annual rates for life table
@@ -369,11 +382,13 @@ calculate_le_all_ages <- function(df, annualize = TRUE) {
   nMx <- nMx[ord]
   age_groups_sorted <- df$age_group[ord]
 
-  # Skip if first age group is too broad for reliable LE calculation
-  # (e.g., 0-24, 0-44, 0-64 from some data sources)
-  if (ages[1] == 0 && !is.na(AgeInt[1]) && AgeInt[1] > MAX_FIRST_AGE_GROUP_WIDTH) {
-    return(tibble(age_group = character(), le = numeric()))
-  }
+  # Flag sources with a broad first age group (e.g., 0-24, 0-44, 0-64).
+  # estimate_nax() falls back to n / 3 for these, so the math still runs but
+  # the first-bucket nax is approximate. The frontend uses this flag to render
+  # a "reduced accuracy" note rather than dropping the series entirely.
+  le_warning <- ages[1] == 0 &&
+    !is.na(AgeInt[1]) &&
+    AgeInt[1] > MAX_FIRST_AGE_GROUP_WIDTH
 
   # Build life table
   lt <- tryCatch(
@@ -382,7 +397,7 @@ calculate_le_all_ages <- function(df, annualize = TRUE) {
   )
 
   if (is.null(lt)) {
-    return(tibble(age_group = character(), le = numeric()))
+    return(empty_result)
   }
 
   # Return ex for all ages
@@ -391,6 +406,7 @@ calculate_le_all_ages <- function(df, annualize = TRUE) {
 
   tibble(
     age_group = age_groups_sorted,
-    le = round(ex, 2)
+    le = round(ex, 2),
+    le_warning = le_warning
   )
 }

--- a/mortality/world_dataset.r
+++ b/mortality/world_dataset.r
@@ -121,17 +121,19 @@ process_country <- function(df) {
       group_by(iso3c, date, type, source) |>
       slice(1) |>
       ungroup() |>
-      select(iso3c, date, type, source, n_age_groups, le)
+      select(iso3c, date, type, source, n_age_groups, le, le_warning)
 
-    # Pick best LE per date (prefer non-NA with highest n_age_groups)
-    # This allows using eurostat LE even when destatis is preferred for deaths
+    # Pick best LE per date (prefer non-NA with highest n_age_groups).
+    # Sorting by n_age_groups desc also pushes broad-first-bucket sources
+    # (le_warning == TRUE) to the back when a finer source is available.
+    # This allows using eurostat LE even when destatis is preferred for deaths.
     dd_le_best <- dd_le_e0 |>
       filter(!is.na(le)) |>
       group_by(iso3c, date) |>
       arrange(desc(n_age_groups)) |>
       slice(1) |>
       ungroup() |>
-      select(iso3c, date, le, source_le = source)
+      select(iso3c, date, le, le_warning, source_le = source)
 
     # Merge best LE into ASMR data (not requiring source match)
     dd_asmr <- dd_asmr |>
@@ -140,7 +142,8 @@ process_country <- function(df) {
     # Merge LE into age-specific data (for individual age group outputs)
     dd_age <- dd_age |>
       left_join(
-        dd_le_all |> select(iso3c, date, type, source, age_group, le),
+        dd_le_all |>
+          select(iso3c, date, type, source, age_group, le, le_warning),
         by = c("iso3c", "date", "type", "source", "age_group")
       )
   }

--- a/mortality/world_dataset_functions.r
+++ b/mortality/world_dataset_functions.r
@@ -19,6 +19,13 @@ filter_by_complete_temp_values <- function(data, fun_name, n) {
     group_by(across(all_of(c("iso3c", fun_name))))
 }
 
+# Aggregate the per-period le_warning flag. A period is flagged when at least
+# one daily input row carried le_warning == TRUE; NAs are ignored and a fully
+# NA period stays NA.
+agg_le_warning <- function(x) {
+  if (length(x) == 0 || all(is.na(x))) NA else any(x, na.rm = TRUE)
+}
+
 aggregate_data <- function(data, type) {
   # Filter ends
   result <- switch(type,
@@ -30,6 +37,7 @@ aggregate_data <- function(data, type) {
     "midyear" = filter_by_complete_temp_values(data, type, 365)
   )
   has_le <- "le" %in% names(data)
+  has_le_warning <- "le_warning" %in% names(data)
 
   if ("cmr" %in% names(data)) {
     if (has_le) {
@@ -39,12 +47,17 @@ aggregate_data <- function(data, type) {
           population = round(mean(.data$population)),
           cmr = round(sum_if_not_empty(.data$cmr), digits = 1),
           le = round(mean(.data$le, na.rm = TRUE), 2),
+          le_warning = if (has_le_warning) {
+            agg_le_warning(.data$le_warning)
+          } else {
+            NA
+          },
           type = toString(unique(.data$type)),
           source = toString(unique(.data$source)),
           .groups = "drop"
         )
       if (all(is.na(result$le) | is.nan(result$le))) {
-        result <- result |> select(-le)
+        result <- result |> select(-le, -le_warning)
       }
     } else {
       result <- result |>
@@ -69,12 +82,17 @@ aggregate_data <- function(data, type) {
           asmr_usa = round(sum_if_not_empty(.data$asmr_usa), digits = 1),
           asmr_country = round(sum_if_not_empty(.data$asmr_country), digits = 1),
           le = round(mean(.data$le, na.rm = TRUE), 2),
+          le_warning = if (has_le_warning) {
+            agg_le_warning(.data$le_warning)
+          } else {
+            NA
+          },
           source_asmr = toString(unique(.data$source)),
           source_le = if (has_source_le) toString(unique(.data$source_le)) else NA_character_,
           .groups = "drop"
         )
       if (all(is.na(result$le) | is.nan(result$le))) {
-        result <- result |> select(-le, -source_le)
+        result <- result |> select(-le, -le_warning, -source_le)
       }
     } else {
       result <- result |>
@@ -130,6 +148,19 @@ calc_sma <- function(data, n) {
   }
   if ("le_adj" %in% colnames(data)) {
     data$le_adj <- round(sma(data$le_adj, n = n), 2)
+  }
+  if ("le_warning" %in% colnames(data)) {
+    # Rolling-OR: a smoothed point inherits the warning if any input in the
+    # window came from a low-resolution source. Aligns with the SMA window.
+    flag <- data$le_warning
+    out <- rep(NA, length(flag))
+    if (length(flag) >= n) {
+      for (i in n:length(flag)) {
+        win <- flag[(i - n + 1):i]
+        out[i] <- if (all(is.na(win))) NA else any(win, na.rm = TRUE)
+      }
+    }
+    data$le_warning <- out
   }
   data
 }


### PR DESCRIPTION
## Summary
Issue #15: Brandenburg (DEU-BB) had no Life Expectancy because `calculate_le_all_ages()` and `calculate_e0()` short-circuited to NA whenever the first age group was wider than `MAX_FIRST_AGE_GROUP_WIDTH = 15` years. Brandenburg's source publishes `0-64 / 65-74 / 75-84 / 85+`, so LE was never written.

`estimate_nax()` already has an `n / 3` fallback for broad first buckets, so the Chiang life table runs cleanly — the result is just less accurate in that first interval. This PR removes the early returns and instead emits a per-row warning flag the frontend can pick up.

## What changed
- `lib/life_expectancy.r`
  - Drop the early `return(NA_real_)` / `return(empty tibble)` in `calculate_e0()` and `calculate_le_all_ages()` for broad first buckets.
  - `calculate_le_all_ages()` now returns a third column `le_warning :: logical`, set to `TRUE` when `ages[1] == 0 && AgeInt[1] > MAX_FIRST_AGE_GROUP_WIDTH`.
  - `MAX_FIRST_AGE_GROUP_WIDTH` is unchanged — it's now the threshold for the warning rather than a hard reject.
  - All other validity checks are preserved: NA / NaN / Inf / `<= 0` / `> 120` clamp on `e0` and `ex`, plus the `tryCatch` around `chiang_life_table`.
- `mortality/world_dataset.r` — plumb `le_warning` through the LE merges:
  - `dd_le_e0` keeps the new column.
  - `dd_le_best` carries it alongside `source_le` into the ASMR join.
  - `dd_le_all` carries it into the per-age join.
  - The `arrange(desc(n_age_groups))` tie-break naturally pushes warned sources to the back when a finer source is available for the same date.
- `mortality/world_dataset_functions.r`
  - `aggregate_data()` aggregates `le_warning` per period bucket via a small `agg_le_warning()` helper (`any()` with `NA` handling). When LE is fully NA for a period, `le_warning` is dropped alongside `le` (and `source_le`).
  - `calc_sma()` does a rolling-OR over the same window as the SMA, so the smoothed LE series stays flagged where any input window was warned.
  - `smooth_le_stl()` preserves columns it doesn't touch, so `le_warning` flows through unchanged for the seasonally-adjusted output.

## Schema choice
**Option A** (logical `le_warning` column) — chosen over Option B (`n_age_groups` threshold).

Reasoning:
- The threshold logic lives in one place (`life_expectancy.r`), where the `MAX_FIRST_AGE_GROUP_WIDTH` constant already defines the boundary. Frontend doesn't need to know that 4 buckets means warned (Brandenburg) but 5 doesn't (some normal sources), or that mortality.org's 5 covers `0-14, 15-64, …` and is fine while Brandenburg's 4 starts at `0-64` and isn't.
- `n_age_groups` was already only used internally for source ranking and was dropped before publication (`select(iso3c, date, le, source_le = source)`), so plumbing it through to the published rows would have been the same level of work as A — without the semantic clarity.
- One extra logical column per LE row; cleanly omitted when the period has no LE at all.

## Frontend follow-up
`mortality.watch` will need a small change to read `le_warning` from the published `mortality/{iso3c}/*.csv` rows and surface a "reduced accuracy" note in the LE chart caption / metric availability tooltip for warned series. Without that the data is still correct — the chart just won't flag the lower confidence.

## Test plan
- [x] `Rscript -e 'parse(...)'` on all three modified files — passes.
- [x] Brandenburg-shaped synthetic input (`0-64 / 65-74 / 75-84 / 85+`): `calculate_le_all_ages()` now returns rows with `le_warning = TRUE`; `calculate_e0()` returns ~68 instead of NA.
- [x] Standard 10-year input (`0-9 / 10-19 / … / 90+`): `calculate_le_all_ages()` returns rows with `le_warning = FALSE`; values unchanged.
- [ ] Spot-check on the live pipeline: `STAGE=1 ISO3C=DEU-BB Rscript update_datasets.r` and confirm `mortality/DEU-BB/yearly.csv` now has an `le` column (with `le_warning = TRUE`) and that `mortality/DEU/yearly.csv` is unchanged.

Fixes #15