### PR TITLE
Recompute yearly LE from annual age-stratified mortality; drop anomalous source rows

### DIFF
--- a/mortality/world_dataset.r
+++ b/mortality/world_dataset.r
@@ -96,6 +96,12 @@ process_country <- function(df) {
   yearweek <- yearweek
   dd <- df |>
     expand_daily() |>
+    # Drop daily rows whose source-period total deaths is implausibly low vs.
+    # neighbours of the same series — e.g. CDC's near-empty Feb 2025 monthly
+    # bucket that otherwise wins the priority race against mortality.org's
+    # complete row and produces deaths=3927 / cmr=1.1 in the published
+    # monthly output (issue #17).
+    filter_anomalous_periods() |>
     mutate(cmr = deaths / population * 100000)
 
   dd_all <- dd |> filter(age_group == "all")
@@ -124,14 +130,18 @@ process_country <- function(df) {
       select(iso3c, date, type, source, n_age_groups, le)
 
     # Pick best LE per date (prefer non-NA with highest n_age_groups)
-    # This allows using eurostat LE even when destatis is preferred for deaths
+    # This allows using eurostat LE even when destatis is preferred for deaths.
+    # Also retain the LE source's `type` (1=yearly, 2=monthly, 3=weekly) as
+    # `le_source_type` so downstream period aggregation can detect when the
+    # default mean(le) would be averaging sub-yearly single-period LE values
+    # (issue #17 / #16).
     dd_le_best <- dd_le_e0 |>
       filter(!is.na(le)) |>
       group_by(iso3c, date) |>
       arrange(desc(n_age_groups)) |>
       slice(1) |>
       ungroup() |>
-      select(iso3c, date, le, source_le = source)
+      select(iso3c, date, le, source_le = source, le_source_type = type)
 
     # Merge best LE into ASMR data (not requiring source match)
     dd_asmr <- dd_asmr |>
@@ -142,6 +152,12 @@ process_country <- function(df) {
       left_join(
         dd_le_all |> select(iso3c, date, type, source, age_group, le),
         by = c("iso3c", "date", "type", "source", "age_group")
+      ) |>
+      # Attach the LE-source type so age-level outputs can also recompute
+      # yearly LE rather than averaging sub-yearly source LEs.
+      left_join(
+        dd_le_best |> select(iso3c, date, le_source_type),
+        by = c("iso3c", "date")
       )
   }
 
@@ -161,9 +177,33 @@ process_country <- function(df) {
   dd_age_monthly <- filter_by_priority(dd_age, priority_monthly, min_type_for_output["yearmonth"])
   dd_age_yearly <- filter_by_priority(dd_age, priority_yearly, min_type_for_output["year"])
 
+  # Recompute period-level LE from annual age-stratified mortality for the
+  # three aggregations whose default mean(le) is structurally wrong when the
+  # underlying LE source is sub-yearly (issue #17 also fixes #16).
+  # `dd_age_yearly` feeds the "year" aggregation; "fluseason" and "midyear"
+  # are aggregated from the monthly age data (mirroring summarize_data_all
+  # below at lines using dd_*_monthly for those types).
+  recomp_le_yearly    <- recompute_period_le(dd_age_yearly,  "year")
+  recomp_le_fluseason <- recompute_period_le(dd_age_monthly, "fluseason")
+  recomp_le_midyear   <- recompute_period_le(dd_age_monthly, "midyear")
+
   for (ag in unique(dd$age_group)) {
     print(paste0("Age Group: ", ag))
     if (ag == "all") {
+      # For year / fluseason / midyear, override the default mean(le)
+      # aggregation with LE recomputed from annual age-stratified mortality
+      # whenever the underlying LE source is sub-yearly. See issue #17 / #16
+      # and recompute_period_le() docstring for why this is necessary.
+      yearly_agg <- summarize_data_all(dd_all_yearly, dd_asmr_yearly,
+          type = "year") |>
+        override_le_with_recomputed(recomp_le_yearly)
+      fluseason_agg <- summarize_data_all(dd_all_monthly, dd_asmr_monthly,
+          type = "fluseason") |>
+        override_le_with_recomputed(recomp_le_fluseason)
+      midyear_agg <- summarize_data_all(dd_all_monthly, dd_asmr_monthly,
+          type = "midyear") |>
+        override_le_with_recomputed(recomp_le_midyear)
+
       write_dataset(
         iso3c, ag,
         weekly = summarize_data_all(dd_all_weekly, dd_asmr_weekly,
@@ -175,15 +215,9 @@ process_country <- function(df) {
         quarterly = summarize_data_all(dd_all_monthly, dd_asmr_monthly,
           type = "yearquarter"
         ),
-        yearly = summarize_data_all(dd_all_yearly, dd_asmr_yearly,
-          type = "year"
-        ),
-        by_fluseason = summarize_data_all(dd_all_monthly, dd_asmr_monthly,
-          type = "fluseason"
-        ),
-        by_midyear = summarize_data_all(dd_all_monthly, dd_asmr_monthly,
-          type = "midyear"
-        )
+        yearly = yearly_agg,
+        by_fluseason = fluseason_agg,
+        by_midyear = midyear_agg
       )
     } else {
       dd_ag_f_weekly <- dd_age_weekly |>

--- a/mortality/world_dataset_functions.r
+++ b/mortality/world_dataset_functions.r
@@ -1,3 +1,221 @@
+# Drop daily rows belonging to a (iso3c, source, age_group, type) source-period
+# whose total deaths is implausibly low compared to neighbouring periods of the
+# same series. This catches partial / sentinel rows that a publisher emits at
+# the leading edge of their data (e.g. CDC publishing an essentially empty
+# Feb 2025 monthly bucket which then wins the priority race against
+# mortality.org's complete row — see issue #17).
+#
+# The rule is data-shape-driven, not country-specific: for each source-period,
+# compare its total deaths against the median of up to `window` neighbouring
+# periods of the same series (excluding self). Drop the period if its total is
+# below `min_ratio` of that neighbour median (and the median is non-trivial).
+filter_anomalous_periods <- function(
+    dd,
+    window = 12,
+    min_ratio = 0.2,
+    min_neighbour_median = 100) {
+  if (nrow(dd) == 0) return(dd)
+  if (!all(c("type", "source", "age_group", "deaths") %in% names(dd))) {
+    return(dd)
+  }
+
+  # Source-native period id per row
+  dd_marked <- dd |>
+    mutate(period_id = case_when(
+      .data$type == 3 ~ as.character(tsibble::yearweek(.data$date)),
+      .data$type == 2 ~ as.character(tsibble::yearmonth(.data$date)),
+      TRUE            ~ as.character(year(.data$date))
+    ))
+
+  # Recover the original source-row total deaths by summing the daily rows
+  # produced by expand_daily() for each source-period.
+  totals <- dd_marked |>
+    group_by(.data$iso3c, .data$source, .data$age_group, .data$type, .data$period_id) |>
+    summarise(period_deaths = sum(.data$deaths, na.rm = TRUE), .groups = "drop") |>
+    arrange(.data$iso3c, .data$source, .data$age_group, .data$type, .data$period_id)
+
+  # For each row: median of up to `window` surrounding rows of the same series
+  # (centred, excluding self). Uses base R rather than zoo::rollapply to avoid
+  # leading/trailing NA blocks at the edges where we most need the check.
+  totals <- totals |>
+    group_by(.data$iso3c, .data$source, .data$age_group, .data$type) |>
+    mutate(neighbour_median = neighbour_median_excluding_self(.data$period_deaths, window)) |>
+    ungroup()
+
+  # Only flag rows that are (a) far below their neighbours' median AND
+  # (b) belong to a series with non-trivial volume — Poisson noise alone can
+  # drop a tiny series (e.g. <100 deaths/month) below 20 % of its median,
+  # so we don't second-guess publishers in that regime.
+  bad <- totals |>
+    filter(
+      !is.na(.data$neighbour_median),
+      .data$neighbour_median >= min_neighbour_median,
+      .data$period_deaths < min_ratio * .data$neighbour_median
+    )
+
+  if (nrow(bad) > 0) {
+    bad |>
+      mutate(msg = sprintf(
+        "[filter_anomalous_periods] dropping %s/%s/%s type=%s %s: deaths=%g vs neighbour median=%g",
+        .data$iso3c, .data$source, .data$age_group, .data$type,
+        .data$period_id, .data$period_deaths, .data$neighbour_median
+      )) |>
+      pull("msg") |>
+      walk(message)
+  }
+
+  dd_marked |>
+    anti_join(
+      bad |> select("iso3c", "source", "age_group", "type", "period_id"),
+      by = c("iso3c", "source", "age_group", "type", "period_id")
+    ) |>
+    select(-"period_id")
+}
+
+# Median of up to `window` neighbours centred on each position, excluding self.
+# Falls back to the median of whatever neighbours exist (so edge positions still
+# get a check), and returns NA only when there are zero neighbours.
+neighbour_median_excluding_self <- function(x, window) {
+  n <- length(x)
+  half <- window %/% 2
+  vapply(seq_len(n), function(i) {
+    lo <- max(1, i - half)
+    hi <- min(n, i + half)
+    others <- x[setdiff(lo:hi, i)]
+    if (length(others) == 0) return(NA_real_)
+    median(others, na.rm = TRUE)
+  }, numeric(1))
+}
+
+# Recompute period-level (yearly / fluseason / midyear) life expectancy from
+# annual age-stratified mortality, using calculate_e0() from lib/life_expectancy.r.
+#
+# Why this exists (issue #17, also #16):
+# When the LE source is sub-yearly (eurostat monthly LE for DEU, mortality.org
+# weekly LE for USA, ...), each published `le` value is itself an annualised
+# *single-period* estimate with strong seasonality (DEU 2025 monthly LEs swing
+# 64-72). Averaging those — which is what the default mean(le) aggregator does
+# — gives the seasonal mean of an estimator that wasn't designed to be
+# averaged, not the country's true annual LE. The only mathematically
+# defensible aggregation is to recompute LE from the year's age-stratified
+# mortality sums.
+#
+# `dd_age_input` is the priority-filtered, daily-expanded age-stratified frame
+# that feeds the period aggregation (dd_age_yearly for "year",
+# dd_age_monthly for "fluseason"/"midyear"). Returns a tibble with columns
+# (iso3c, period, le_recomputed, has_subyearly_le_source).
+recompute_period_le <- function(dd_age_input, type) {
+  empty <- tibble(
+    iso3c = character(), period = character(),
+    le_recomputed = numeric(), has_subyearly_le_source = logical()
+  )
+  if (!type %in% c("year", "fluseason", "midyear")) return(empty)
+  if (nrow(dd_age_input) == 0) return(empty)
+  required <- c("age_group", "deaths", "population", "type", "source", "n_age_groups")
+  if (!all(required %in% names(dd_age_input))) return(empty)
+
+  fun <- get(type)
+  dd <- dd_age_input |> mutate(period = as.character(fun(.data$date)))
+
+  # Per (iso3c, period): does any contributing row come from a sub-yearly LE
+  # source? If `le_source_type` was attached upstream, prefer it; otherwise
+  # fall back to the row's own `type` (which equals the LE source type in the
+  # age-stratified path, since LE is computed per source row).
+  src_col <- if ("le_source_type" %in% names(dd)) "le_source_type" else "type"
+  has_sub <- dd |>
+    group_by(.data$iso3c, .data$period) |>
+    summarise(
+      has_subyearly_le_source = any(.data[[src_col]] != 1, na.rm = TRUE),
+      .groups = "drop"
+    )
+
+  # Day-coverage per (iso3c, period, source): how many distinct days does this
+  # source contribute to the period? Used to skip sources with incomplete
+  # period coverage (e.g. CDC USA 2025 missing Feb after the anomaly filter
+  # would otherwise produce an under-estimated mortality rate / over-estimated
+  # LE if used for recomputation).
+  coverage <- dd |>
+    distinct(.data$iso3c, .data$period, .data$source, .data$date) |>
+    group_by(.data$iso3c, .data$period, .data$source) |>
+    summarise(coverage_days = n(), .groups = "drop")
+
+  period_days <- dd |>
+    distinct(.data$iso3c, .data$period, .data$date) |>
+    group_by(.data$iso3c, .data$period) |>
+    summarise(period_total_days = n(), .groups = "drop")
+
+  coverage <- coverage |>
+    left_join(period_days, by = c("iso3c", "period")) |>
+    mutate(coverage_ratio = .data$coverage_days / .data$period_total_days)
+
+  # Recompute LE per (iso3c, period, source, n_age_groups): sum daily deaths
+  # back to period totals per age group within ONE source/age-scheme combo
+  # (mixing schemes across sources would corrupt the life table), then run
+  # calculate_e0 with annualize=FALSE since deaths are already annualised.
+  per_source <- dd |>
+    group_by(.data$iso3c, .data$period, .data$source, .data$n_age_groups,
+             .data$age_group) |>
+    summarise(
+      deaths = sum(.data$deaths, na.rm = TRUE),
+      population = mean(.data$population, na.rm = TRUE),
+      .groups = "drop"
+    ) |>
+    group_by(.data$iso3c, .data$period, .data$source, .data$n_age_groups) |>
+    group_modify(~ tibble(le_recomputed = calculate_e0(.x, annualize = FALSE))) |>
+    ungroup() |>
+    left_join(coverage, by = c("iso3c", "period", "source"))
+
+  # Pick the best per (iso3c, period): require >=90% day coverage of the
+  # period (else mortality rate is biased low → LE biased high), prefer
+  # non-NA, then highest n_age_groups (matches dd_le_best's selection for
+  # sub-yearly LE).
+  recomputed <- per_source |>
+    filter(
+      !is.na(.data$le_recomputed),
+      .data$coverage_ratio >= 0.9
+    ) |>
+    group_by(.data$iso3c, .data$period) |>
+    arrange(desc(.data$n_age_groups), desc(.data$coverage_ratio)) |>
+    slice(1) |>
+    ungroup() |>
+    select("iso3c", "period", "le_recomputed")
+
+  recomputed |>
+    left_join(has_sub, by = c("iso3c", "period")) |>
+    mutate(has_subyearly_le_source = coalesce(.data$has_subyearly_le_source, FALSE))
+}
+
+# Override `le` in an aggregated period frame with the value from
+# recompute_period_le() when (a) a recomputed value is available and (b) the
+# original le was a mean of sub-yearly source values (i.e. structurally wrong
+# under the default mean(le) aggregation — see issue #17). Yearly-source LE
+# values (destatis annual etc.) are kept untouched.
+override_le_with_recomputed <- function(aggregated, recomputed) {
+  if (nrow(aggregated) == 0 || !"le" %in% names(aggregated)) return(aggregated)
+  if (nrow(recomputed) == 0) return(aggregated)
+
+  # `aggregated$date` carries the period label (numeric year, or string
+  # like "2024-2025"); coerce both sides to character for a robust join.
+  rhs <- recomputed |>
+    mutate(period_key = as.character(.data$period)) |>
+    select("period_key", "le_recomputed", "has_subyearly_le_source")
+
+  joined <- aggregated |>
+    mutate(period_key = as.character(.data$date)) |>
+    left_join(rhs, by = "period_key") |>
+    select(-"period_key")
+
+  joined |>
+    mutate(
+      le = if_else(
+        !is.na(.data$le_recomputed) & coalesce(.data$has_subyearly_le_source, FALSE),
+        round(.data$le_recomputed, 2),
+        .data$le
+      )
+    ) |>
+    select(-any_of(c("le_recomputed", "has_subyearly_le_source")))
+}
+
 filter_by_complete_temp_values <- function(data, fun_name, n) {
   start <- data |>
     filter(.data[[fun_name]] == head(data[[fun_name]], n = 1)) |>


### PR DESCRIPTION
## Summary
Fixes the two compounding causes of the wrong USA 2025 / DEU 2025 yearly LE values, plus the same structural bug for the midyear and fluseason aggregations.

**Bug #1 — `mean(monthly_le)` is structurally wrong.**
`mortality/world_dataset_functions.r` aggregated yearly / fluseason / midyear LE via `mean(.data$le, na.rm = TRUE)`. That is correct only when the LE source is a single annual row (e.g. destatis 2024 yearly). When the LE source is sub-yearly (eurostat monthly LE for DEU, mortality.org weekly LE for USA), each input is itself an annualised single-period estimate with strong seasonality, and averaging them gives the seasonal mean of an estimator that wasn't designed to be averaged. The DEU 2025 monthly LE swings 64-72; mean = 68.5; true value is ~82.

`process_country` now recomputes the period LE from the period's annual age-stratified mortality using `calculate_e0` from `lib/life_expectancy.r`, and only overrides the default `mean(le)` when the underlying LE source is sub-yearly (`le_source_type != 1`). Yearly-source LE values (destatis 2024 etc.) pass through untouched. Falls back to the existing `mean(le)` when the recomputation can't run (no usable age scheme, < 90 % day coverage of the period for any single source).

**Bug #2 — corrupted USA Feb 2025 row.**
CDC published a Feb 2025 monthly row with deaths = 3927 (vs ~250k normal). Because CDC outranks mortality.org in `priority_dataset`, that row wins the priority race and produces CMR ~1.1 in the published monthly output. A new `filter_anomalous_periods()` runs immediately after `expand_daily()` and drops daily rows belonging to a (iso3c, source, age_group, type) source-period whose total deaths is < 20 % of its neighbour median — but only when the median itself exceeds 100 deaths (so we don't second-guess publishers in the Poisson-noise regime for tiny series).

The rule is data-shape-driven, not country-specific. A `message()` is emitted for each dropped period so it's debuggable.

This subsumes #16 (DEU midyear LE 74.54): the midyear aggregation has the same `mean(le)` bug and the same fix applies.

**Three things this fixes**:
- USA 2025 yearly: removes the Feb 2025 corruption from CMR/ASMR; LE recomputed from annual age-stratified mortality (mortality.org's complete weekly age data).
- DEU 2025 yearly: LE goes from 68.53 (mean of seasonal eurostat monthly LEs) to a recomputed value derived from 2025 age-stratified annual mortality.
- DEU 2024-25 midyear: same root cause as #16, same fix.

## Trade-offs
- The anomaly filter at `< 0.2 × neighbour median, median ≥ 100` is intentionally permissive: it only catches egregious sentinel / empty rows. It does NOT touch normal seasonality (winter/summer swings stay above 50 % of the annual median in every published series I checked) and it does NOT touch tiny-volume countries (median floor of 100). It MAY suppress a legitimate partial period for a country with severe reporting lag (e.g. < 6 days of a month published mid-cycle) — but those rows would distort the aggregate anyway and dropping them is the right call until the publisher backfills.
- LE recomputation requires age-stratified data with a first age group ≤ 15 years wide (`MAX_FIRST_AGE_GROUP_WIDTH` in `lib/life_expectancy.r`). For sources that fail that check the fallback is the existing `mean(le)`, which is no worse than today.
- Yearly LE rounded to 2 dp to match the existing aggregator. `source_le` is left untouched (still names the original LE provider) — happy to add a `(recomputed)` tag later if useful.

## Test plan
- [ ] Verify USA 2025 yearly row: deaths back near 3M (Feb 2025 dropped), CMR / ASMR / LE all in line with 2024.
- [ ] Verify DEU 2025 yearly row: LE recomputed from 2025 age-stratified mortality (~82 expected, not 68.5).
- [ ] Verify DEU 2024-25 midyear (#16): LE recomputed; not 74.54.
- [ ] Verify DEU 2024 yearly row: LE remains 81.67 (destatis annual source, type=1, override does NOT trigger).
- [ ] Spot-check a country with only sub-yearly LE for several years (FRA / NLD / SWE) to make sure the new path produces plausible numbers across multiple years, not just the latest one.
- [ ] Spot-check small countries (ISL, LUX, AFG) to confirm the anomaly filter does not drop legitimate low-volume periods (`min_neighbour_median = 100` should be enough margin).
- [ ] Grep the build log for `[filter_anomalous_periods]` lines and eyeball each for plausibility.

Fixes #17, #16