### PR TITLE
fix(le): emit le_unavailable_reason instead of silently dropping LE

### DIFF
--- a/lib/life_expectancy.r
+++ b/lib/life_expectancy.r
@@ -332,18 +332,29 @@ parse_age_groups_for_le <- function(age_groups) {
 #'   Deaths should be daily counts (annual deaths / 365) when annualize=TRUE.
 #' @param annualize Logical: if TRUE (default), multiply mortality rates by 365
 #'   to convert daily rates to annual rates. Set to FALSE for annual data.
-#' @return Data frame with age_group and le columns
+#' @return Data frame with age_group, le, and le_unavailable_reason columns.
+#'   `le_unavailable_reason` is `NA_character_` when LE is computable, otherwise
+#'   a short machine-readable string explaining why LE is unavailable (e.g.
+#'   "first_age_group_too_broad" when the source's first age bucket is wider
+#'   than `MAX_FIRST_AGE_GROUP_WIDTH`). Frontends can read this column to
+#'   render an explanation instead of silently disabling the metric.
 calculate_le_all_ages <- function(df, annualize = TRUE) {
+  empty_result <- tibble(
+    age_group = character(),
+    le = numeric(),
+    le_unavailable_reason = character()
+  )
+
   # Need at least some data
   if (nrow(df) == 0) {
-    return(tibble(age_group = character(), le = numeric()))
+    return(empty_result)
   }
 
   # Parse age groups to get numeric starts
   age_info <- parse_age_groups_for_le(df$age_group)
 
   if (is.null(age_info) || length(age_info$ages) < 2) {
-    return(tibble(age_group = character(), le = numeric()))
+    return(empty_result)
   }
 
   # Calculate mortality rates (deaths per person, NOT per 100k)
@@ -354,7 +365,7 @@ calculate_le_all_ages <- function(df, annualize = TRUE) {
 
   # Check if all mortality rates are zero (no deaths)
   if (all(nMx == 0)) {
-    return(tibble(age_group = character(), le = numeric()))
+    return(empty_result)
   }
 
   # Annualize daily mortality rates to get annual rates for life table
@@ -370,9 +381,16 @@ calculate_le_all_ages <- function(df, annualize = TRUE) {
   age_groups_sorted <- df$age_group[ord]
 
   # Skip if first age group is too broad for reliable LE calculation
-  # (e.g., 0-24, 0-44, 0-64 from some data sources)
+  # (e.g., 0-24, 0-44, 0-64 from some data sources). Return NA `le` plus a
+  # reason on every age row so downstream consumers (and ultimately the
+  # frontend) can explain *why* LE is unavailable instead of silently
+  # dropping the metric. See issue #15 / closed PR #20 for context.
   if (ages[1] == 0 && !is.na(AgeInt[1]) && AgeInt[1] > MAX_FIRST_AGE_GROUP_WIDTH) {
-    return(tibble(age_group = character(), le = numeric()))
+    return(tibble(
+      age_group = age_groups_sorted,
+      le = NA_real_,
+      le_unavailable_reason = "first_age_group_too_broad"
+    ))
   }
 
   # Build life table
@@ -382,7 +400,7 @@ calculate_le_all_ages <- function(df, annualize = TRUE) {
   )
 
   if (is.null(lt)) {
-    return(tibble(age_group = character(), le = numeric()))
+    return(empty_result)
   }
 
   # Return ex for all ages
@@ -391,6 +409,7 @@ calculate_le_all_ages <- function(df, annualize = TRUE) {
 
   tibble(
     age_group = age_groups_sorted,
-    le = round(ex, 2)
+    le = round(ex, 2),
+    le_unavailable_reason = NA_character_
   )
 }

--- a/mortality/world_dataset.r
+++ b/mortality/world_dataset.r
@@ -158,12 +158,15 @@ process_country <- function(df) {
       group_by(iso3c, date) |>
       arrange(desc(n_age_groups)) |>
       slice(1) |>
-      ungroup()
+      ungroup() |>
+      select(
+        iso3c, date, le, le_unavailable_reason,
+        source_le = source, le_source_type = type
+      )
 
     dd_le_best <- bind_rows(dd_le_best_computed, dd_le_best_unavailable) |>
       select(
-        iso3c, date, le, le_unavailable_reason,
-        source_le = source, le_source_type
+        iso3c, date, le, le_unavailable_reason, source_le, le_source_type
       )
 
     # Merge best LE into ASMR data (not requiring source match)

--- a/mortality/world_dataset.r
+++ b/mortality/world_dataset.r
@@ -127,7 +127,7 @@ process_country <- function(df) {
       group_by(iso3c, date, type, source) |>
       slice(1) |>
       ungroup() |>
-      select(iso3c, date, type, source, n_age_groups, le)
+      select(iso3c, date, type, source, n_age_groups, le, le_unavailable_reason)
 
     # Pick best LE per date (prefer non-NA with highest n_age_groups)
     # This allows using eurostat LE even when destatis is preferred for deaths.
@@ -135,13 +135,36 @@ process_country <- function(df) {
     # `le_source_type` so downstream period aggregation can detect when the
     # default mean(le) would be averaging sub-yearly single-period LE values
     # (issue #17 / #16).
-    dd_le_best <- dd_le_e0 |>
+    # When *no* source can compute LE for this jurisdiction/date (e.g.
+    # Brandenburg only publishes 0-64 as the first bucket — see issue #15),
+    # all candidates have `le = NA`. In that case we still want to surface a
+    # row so the unavailability reason flows through to consumers; without
+    # this branch the prior `filter(!is.na(le))` would drop them all and the
+    # frontend would see no row at all.
+    dd_le_best_computed <- dd_le_e0 |>
       filter(!is.na(le)) |>
       group_by(iso3c, date) |>
       arrange(desc(n_age_groups)) |>
       slice(1) |>
       ungroup() |>
-      select(iso3c, date, le, source_le = source, le_source_type = type)
+      select(
+        iso3c, date, le, le_unavailable_reason,
+        source_le = source, le_source_type = type
+      )
+
+    dd_le_best_unavailable <- dd_le_e0 |>
+      anti_join(dd_le_best_computed, by = c("iso3c", "date")) |>
+      filter(!is.na(le_unavailable_reason)) |>
+      group_by(iso3c, date) |>
+      arrange(desc(n_age_groups)) |>
+      slice(1) |>
+      ungroup()
+
+    dd_le_best <- bind_rows(dd_le_best_computed, dd_le_best_unavailable) |>
+      select(
+        iso3c, date, le, le_unavailable_reason,
+        source_le = source, le_source_type
+      )
 
     # Merge best LE into ASMR data (not requiring source match)
     dd_asmr <- dd_asmr |>
@@ -150,7 +173,10 @@ process_country <- function(df) {
     # Merge LE into age-specific data (for individual age group outputs)
     dd_age <- dd_age |>
       left_join(
-        dd_le_all |> select(iso3c, date, type, source, age_group, le),
+        dd_le_all |>
+          select(
+            iso3c, date, type, source, age_group, le, le_unavailable_reason
+          ),
         by = c("iso3c", "date", "type", "source", "age_group")
       ) |>
       # Attach the LE-source type so age-level outputs can also recompute

--- a/mortality/world_dataset_functions.r
+++ b/mortality/world_dataset_functions.r
@@ -259,6 +259,22 @@ filter_by_complete_temp_values <- function(data, fun_name, n, n_iso_week = n) {
     group_by(across(all_of(c("iso3c", fun_name))))
 }
 
+# Pick the most common non-NA reason (first wins on ties). Returns
+# `NA_character_` when there are no reasons. Used to propagate
+# `le_unavailable_reason` through aggregations where multiple per-period
+# rows collapse into one.
+most_common_reason <- function(x) {
+  if (is.null(x)) {
+    return(NA_character_)
+  }
+  vals <- x[!is.na(x)]
+  if (length(vals) == 0) {
+    return(NA_character_)
+  }
+  tab <- sort(table(vals), decreasing = TRUE)
+  names(tab)[1]
+}
+
 aggregate_data <- function(data, type) {
   # Filter ends. For "year", allow ISO-weekly-sourced years (type == 3) to
   # pass at >= 51 weeks (357 days) since ISO weeks cannot cover all 365
@@ -274,6 +290,7 @@ aggregate_data <- function(data, type) {
     "midyear" = filter_by_complete_temp_values(data, type, 365)
   )
   has_le <- "le" %in% names(data)
+  has_le_reason <- "le_unavailable_reason" %in% names(data)
 
   if ("cmr" %in% names(data)) {
     if (has_le) {
@@ -283,12 +300,32 @@ aggregate_data <- function(data, type) {
           population = round(mean(.data$population)),
           cmr = round(sum_if_not_empty(.data$cmr), digits = 1),
           le = round(mean(.data$le, na.rm = TRUE), 2),
+          le_unavailable_reason = if (has_le_reason) {
+            most_common_reason(.data$le_unavailable_reason)
+          } else {
+            NA_character_
+          },
           type = toString(unique(.data$type)),
           source = toString(unique(.data$source)),
           .groups = "drop"
         )
       if (all(is.na(result$le) | is.nan(result$le))) {
+        # LE itself is uncomputable for every aggregated row; drop the column
+        # but keep `le_unavailable_reason` so the frontend can still explain
+        # why. If no reason was carried through either, drop it too.
         result <- result |> select(-le)
+        if (all(is.na(result$le_unavailable_reason))) {
+          result <- result |> select(-le_unavailable_reason)
+        }
+      } else {
+        # LE is at least partially computable; the reason column is only
+        # meaningful when LE is NA, so blank it out elsewhere.
+        result <- result |>
+          mutate(
+            le_unavailable_reason = ifelse(
+              is.na(.data$le), .data$le_unavailable_reason, NA_character_
+            )
+          )
       }
     } else {
       result <- result |>
@@ -313,12 +350,30 @@ aggregate_data <- function(data, type) {
           asmr_usa = round(sum_if_not_empty(.data$asmr_usa), digits = 1),
           asmr_country = round(sum_if_not_empty(.data$asmr_country), digits = 1),
           le = round(mean(.data$le, na.rm = TRUE), 2),
+          le_unavailable_reason = if (has_le_reason) {
+            most_common_reason(.data$le_unavailable_reason)
+          } else {
+            NA_character_
+          },
           source_asmr = toString(unique(.data$source)),
           source_le = if (has_source_le) toString(unique(.data$source_le)) else NA_character_,
           .groups = "drop"
         )
       if (all(is.na(result$le) | is.nan(result$le))) {
+        # See note in the cmr branch: keep `le_unavailable_reason` so the
+        # frontend can still explain unavailability; drop only when nothing
+        # was carried through.
         result <- result |> select(-le, -source_le)
+        if (all(is.na(result$le_unavailable_reason))) {
+          result <- result |> select(-le_unavailable_reason)
+        }
+      } else {
+        result <- result |>
+          mutate(
+            le_unavailable_reason = ifelse(
+              is.na(.data$le), .data$le_unavailable_reason, NA_character_
+            )
+          )
       }
     } else {
       result <- result |>


### PR DESCRIPTION
## Rationale

Closes #15. Previous attempt #20 was rejected because computing LE
anyway from a too-broad first age bucket (e.g. Brandenburg's 0-64)
gives a ~12y systematic error (e0 ≈ 68 vs. true ~80) — no warning
text salvages a wrong number once it's plotted.

This PR keeps returning `NA` for `le` in that case, but emits the
*reason* in a new column so the frontend can render
"LE not computable — source publishes only `0-64` for this
jurisdiction" instead of silently disabling the metric.

## Schema

New string column **`le_unavailable_reason`** rides alongside `le`:

- `NA_character_` when LE is computable normally.
- `"first_age_group_too_broad"` when the first age bucket exceeds
  `MAX_FIRST_AGE_GROUP_WIDTH` (15) — currently the only reason value
  emitted; the column is open to additional values in the future.

When LE is at least partially computable for an aggregated period,
the reason column is blanked out on rows where `le` is non-NA, so it
only ever appears alongside an actual NA `le` value.

## Scope

- **No math change.** `MAX_FIRST_AGE_GROUP_WIDTH`, the corrupted-row
  filter from #17 / #21, and Chiang's method are all untouched.
- `lib/life_expectancy.r`: `calculate_le_all_ages` returns the new
  column; the broad-first-bucket case now returns rows with
  `le = NA` plus the reason rather than an empty tibble.
  `calculate_e0` still returns `NA_real_` (no schema change needed —
  it returns a scalar).
- `mortality/world_dataset.r`: plumbs the column through
  `dd_le_e0`, `dd_le_best`, and the merges into `dd_asmr` /
  `dd_age`. The "best LE per date" picker now branches: if any
  source can compute LE, behaviour is unchanged; if every source
  hits the same broad-first-bucket condition, we still surface
  one row carrying the reason instead of dropping them all.
- `mortality/world_dataset_functions.r`: `aggregate_data` carries
  the reason through period aggregation via a small
  `most_common_reason` helper. `calc_sma` already preserves
  non-LE columns; `smooth_le_stl` only adds `le_adj`, so neither
  needed structural changes.

## Frontend follow-up

Once this lands and the datasets re-publish, the Explorer can read
`le_unavailable_reason` from the per-jurisdiction CSVs and render
an explanation in the LE selector for jurisdictions like DEU-BB,
rather than greying it out without context.

## Test plan

- [x] `Rscript -e 'parse(...)'` on all three modified files.
- [x] Synthetic Brandenburg-shaped fixture (4 buckets, first =
  `0-64`) → `calculate_le_all_ages` returns 4 rows with
  `le = NA, le_unavailable_reason = "first_age_group_too_broad"`.
- [x] Normal-resolution fixture (10 buckets starting at `0-4`) →
  reason is `NA_character_` on every row.
- [x] `dd_le_best` simulation: all-NA-LE case still emits one row
  carrying the reason; mixed case (one source computes, one
  doesn't) picks the computed one and emits no duplicate.
- [ ] End-to-end pipeline run on a Brandenburg-only `ISO3C` filter
  to confirm the column appears in published CSVs (deferred to
  the maintainer; runner needs the full upstream-data setup).