### PR TITLE
Refresh Cronicle server IP on boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,11 @@ COPY openssl.cnf .
 RUN chown ubuntu:ubuntu /opt/cronicle/openssl.cnf
 ENV OPENSSL_CONF=/opt/cronicle/openssl.cnf
 
+# Local startup helpers
+COPY entrypoint.sh refresh-server-ip.js .
+RUN chmod +x /opt/cronicle/entrypoint.sh /opt/cronicle/refresh-server-ip.js && \
+  chown ubuntu:ubuntu /opt/cronicle/entrypoint.sh /opt/cronicle/refresh-server-ip.js
+
 # Install MinIO Client
 RUN mkdir -p minio-binaries && \ 
 curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc \ 
@@ -87,4 +92,4 @@ EXPOSE 3012
 
 # Set default command
 ENTRYPOINT ["/usr/bin/tini", "-s", "--"]
-CMD ["manager"]
+CMD ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Only run setup when setup needs to be done
-if [ ! -f /opt/cronicle/.setup_done ]; then
-  /opt/cronicle/bin/control.sh setup
-  mv /opt/cronicle/config.json /opt/cronicle/conf/config.json
+# Ensure storage exists before we try to inspect or patch cluster metadata.
+/opt/cronicle/bin/control.sh setup >/dev/null 2>&1 || true
 
-  touch /opt/cronicle/.setup_done
-fi
+# Cronicle stores manager candidates by hostname+IP. In Dokku the container IP
+# changes across deploys, so refresh the persisted IP for the fixed legacy
+# hostname before manager election runs.
+node /opt/cronicle/refresh-server-ip.js
 
-service mariadb start
-mysql -e "set password = password('');"
-
-# Run cronicle
-node /opt/cronicle/lib/main.js
+exec /opt/cronicle/bin/manager "$@"

--- a/refresh-server-ip.js
+++ b/refresh-server-ip.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+const { execFileSync, spawnSync } = require('node:child_process');
+const os = require('node:os');
+
+const STORAGE_CLI = '/opt/cronicle/bin/storage-cli.js';
+const NODE = process.execPath;
+
+function getRuntimeHostname() {
+  return (process.env.CRONICLE_hostname || process.env.HOSTNAME || process.env.HOST || os.hostname()).toLowerCase();
+}
+
+function getRuntimeIp() {
+  const interfaces = os.networkInterfaces();
+
+  for (const infos of Object.values(interfaces)) {
+    if (!infos) continue;
+
+    for (const info of infos) {
+      if (!info || info.internal) continue;
+      if (info.family === 'IPv4' && /^\d+\.\d+\.\d+\.\d+$/.test(info.address)) {
+        return info.address;
+      }
+    }
+  }
+
+  throw new Error('Unable to determine runtime IPv4 address');
+}
+
+function runStorageGet(key) {
+  const output = execFileSync(NODE, [STORAGE_CLI, 'get', key], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  return JSON.parse(output);
+}
+
+function runStoragePut(key, value) {
+  const result = spawnSync(NODE, [STORAGE_CLI, 'put', key], {
+    input: `${JSON.stringify(value)}\n`,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    const stdout = (result.stdout || '').trim();
+    throw new Error(stderr || stdout || `storage-cli put failed for ${key}`);
+  }
+}
+
+function main() {
+  const hostname = getRuntimeHostname();
+  const ip = getRuntimeIp();
+
+  let header;
+  try {
+    header = runStorageGet('global/servers');
+  }
+  catch (error) {
+    console.warn(`[refresh-server-ip] Skipping server IP refresh: ${error.message}`);
+    return;
+  }
+
+  const firstPage = Number.isInteger(header.first_page) ? header.first_page : 0;
+  const lastPage = Number.isInteger(header.last_page) ? header.last_page : 0;
+
+  for (let page = firstPage; page <= lastPage; page += 1) {
+    const key = `global/servers/${page}`;
+    const pageData = runStorageGet(key);
+
+    if (!Array.isArray(pageData.items)) continue;
+
+    const server = pageData.items.find((item) => item && item.hostname === hostname);
+    if (!server) continue;
+
+    if (server.ip === ip) {
+      console.log(`[refresh-server-ip] Server record already current for ${hostname} -> ${ip}`);
+      return;
+    }
+
+    server.ip = ip;
+    runStoragePut(key, pageData);
+    console.log(`[refresh-server-ip] Updated server record for ${hostname}: ${key} -> ${ip}`);
+    return;
+  }
+
+  console.warn(`[refresh-server-ip] No server record found for hostname ${hostname}; leaving storage unchanged`);
+}
+
+main();

--- a/refresh-server-ip.js
+++ b/refresh-server-ip.js
@@ -54,39 +54,38 @@ function main() {
   const hostname = getRuntimeHostname();
   const ip = getRuntimeIp();
 
-  let header;
   try {
+    let header;
     header = runStorageGet('global/servers');
-  }
-  catch (error) {
-    console.warn(`[refresh-server-ip] Skipping server IP refresh: ${error.message}`);
-    return;
-  }
 
-  const firstPage = Number.isInteger(header.first_page) ? header.first_page : 0;
-  const lastPage = Number.isInteger(header.last_page) ? header.last_page : 0;
+    const firstPage = Number.isInteger(header.first_page) ? header.first_page : 0;
+    const lastPage = Number.isInteger(header.last_page) ? header.last_page : 0;
 
-  for (let page = firstPage; page <= lastPage; page += 1) {
-    const key = `global/servers/${page}`;
-    const pageData = runStorageGet(key);
+    for (let page = firstPage; page <= lastPage; page += 1) {
+      const key = `global/servers/${page}`;
+      const pageData = runStorageGet(key);
 
-    if (!Array.isArray(pageData.items)) continue;
+      if (!Array.isArray(pageData.items)) continue;
 
-    const server = pageData.items.find((item) => item && item.hostname === hostname);
-    if (!server) continue;
+      const server = pageData.items.find((item) => item && item.hostname === hostname);
+      if (!server) continue;
 
-    if (server.ip === ip) {
-      console.log(`[refresh-server-ip] Server record already current for ${hostname} -> ${ip}`);
+      if (server.ip === ip) {
+        console.log(`[refresh-server-ip] Server record already current for ${hostname} -> ${ip}`);
+        return;
+      }
+
+      server.ip = ip;
+      runStoragePut(key, pageData);
+      console.log(`[refresh-server-ip] Updated server record for ${hostname}: ${key} -> ${ip}`);
       return;
     }
 
-    server.ip = ip;
-    runStoragePut(key, pageData);
-    console.log(`[refresh-server-ip] Updated server record for ${hostname}: ${key} -> ${ip}`);
-    return;
+    console.warn(`[refresh-server-ip] No server record found for hostname ${hostname}; leaving storage unchanged`);
   }
-
-  console.warn(`[refresh-server-ip] No server record found for hostname ${hostname}; leaving storage unchanged`);
+  catch (error) {
+    console.warn(`[refresh-server-ip] Skipping server IP refresh for ${hostname}: ${error.message}`);
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary
- keep the legacy Cronicle hostname and start through the normal manager launcher
- refresh the persisted `global/servers` IP for that hostname on container boot before manager election
- copy the startup helper into the image and invoke it as the container command

## Context
Cronicle stores manager candidates by hostname and IP. On Dokku, the container IP changes across restarts, but the stored server record kept the old IP, which left the app stuck on `No manager server found` even though the legacy hostname was still correct.

## Verification
- `node --check refresh-server-ip.js`
- verified live recovery separately by updating the stale `global/servers` record and restarting the app