### PR TITLE
Fix recomputed LE period coverage

### DIFF
--- a/mortality/world_dataset_functions.r
+++ b/mortality/world_dataset_functions.r
@@ -135,18 +135,22 @@ recompute_period_le <- function(dd_age_input, type) {
   # would otherwise produce an under-estimated mortality rate / over-estimated
   # LE if used for recomputation).
   coverage <- dd |>
-    distinct(.data$iso3c, .data$period, .data$source, .data$date) |>
+    distinct(.data$iso3c, .data$period, .data$source, .data$type, .data$date) |>
     group_by(.data$iso3c, .data$period, .data$source) |>
-    summarise(coverage_days = n(), .groups = "drop")
-
-  period_days <- dd |>
-    distinct(.data$iso3c, .data$period, .data$date) |>
-    group_by(.data$iso3c, .data$period) |>
-    summarise(period_total_days = n(), .groups = "drop")
+    summarise(
+      coverage_days = n(),
+      source_type = max(.data$type, na.rm = TRUE),
+      .groups = "drop"
+    )
 
   coverage <- coverage |>
-    left_join(period_days, by = c("iso3c", "period")) |>
-    mutate(coverage_ratio = .data$coverage_days / .data$period_total_days)
+    mutate(
+      required_coverage_days = case_when(
+        .env$type == "year" & .data$source_type == 3 ~ 357,
+        TRUE ~ 365
+      ),
+      coverage_ratio = .data$coverage_days / .data$required_coverage_days
+    )
 
   # Recompute LE per (iso3c, period, source, n_age_groups): sum daily deaths
   # back to period totals per age group within ONE source/age-scheme combo


### PR DESCRIPTION
## Summary
- Require recomputed period LE to have coverage against the full target period, not just the dates present in a partial source window
- Preserve the existing relaxed yearly threshold for ISO-week sourced years
- Prevent partial boundary periods, such as Australia 2014/15 flu season, from getting an inflated recomputed LE value

## Verification
- Partial Jan-Sep synthetic flu-season source returns no recomputed LE row
- Complete Oct-Sep synthetic flu-season source still returns a recomputed LE row

## Notes
Production currently has `AUS/fluseason.csv` with `2014-2015 le=85.57`, while the matching age-band flu-season files have no 2014/15 rows. The root cause is that `recompute_period_le()` measured source coverage against the partial dates available in `dd_age_input`, so the first incomplete mortality.org season looked complete and was recomputed from too few deaths.